### PR TITLE
Fixed Broken Pagination Links on Product Admin

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # Vanilo Admin Changelog
 
+## Unreleased
+##### 2023-02-XX
+
+- Fixed broken pagination links on product admin
+
 ## 3.4.0
 ##### 2023-01-25
 

--- a/src/Http/Controllers/ProductController.php
+++ b/src/Http/Controllers/ProductController.php
@@ -35,10 +35,10 @@ class ProductController extends BaseController
             collect($products->items())->merge($masterProducts->items()),
             $products->total() + $masterProducts->total(),
             100,
-        ) ;
+        );
 
         return view('vanilo::product.index', [
-            'products' => $paginator,
+            'products' => $paginator->withPath(route('vanilo.admin.product.index')),
         ]);
     }
 


### PR DESCRIPTION
As the title says: the manual paginator crafted from master and plain products didn't have a proper URL set
