### PR TITLE
Fixed taxon collapse

### DIFF
--- a/src/resources/views/taxon/_tree.blade.php
+++ b/src/resources/views/taxon/_tree.blade.php
@@ -4,6 +4,7 @@
         @if ($taxon->children->isNotEmpty())
             <a href="#taxon-{{$taxon->id}}" aria-expanded="false"
                aria-controls="taxon-{{$taxon->id}}" data-bs-toggle="collapse"
+               role="button"
                class="collapse-toggler-heading">
                 &nbsp;{!! icon('>') !!}
             </a>
@@ -43,7 +44,7 @@
     </div>
 
     @if ($taxon->children->isNotEmpty())
-        <div id="taxon-{{$taxon->id}}" data-bs-toggle="collapse">
+        <div id="taxon-{{$taxon->id}}" class="collapse show">
             <div class="card-body">
                 <div class="card">
                     @include('vanilo::taxon._tree', ['taxons' => $taxon->children])


### PR DESCRIPTION
## Issue:
- The nested taxon links are not opening when clicked.

## Fix:
- The nested taxon links are now opening correctly when clicked.