### PR TITLE
Show Order Item Configuration on Order Items

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 
 - Added the missing order status `processing` enum icon
 - Fixed the invalid icons on carrier and shipping method forms
+- Added modal to display configuration JSON of order items
 
 ## 4.1.0
 ##### 2024-07-11

--- a/src/resources/views/order/show/_item_configuration.blade.php
+++ b/src/resources/views/order/show/_item_configuration.blade.php
@@ -1,0 +1,30 @@
+<div
+    id="item-configuration-{{ $loop->index }}"
+    class="modal fade"
+    tabindex="-1"
+    role="dialog"
+    aria-labelledby="item-configuration-title" aria-hidden="true"
+>
+    <div class="modal-dialog modal-lg" role="document">
+
+        <div class="modal-content">
+
+            <div class="modal-header">
+                <h5 class="modal-title" id="item-configuration-title">
+                    {{ __('Configuration of') }} {{ $item->name }}
+                </h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+
+            <div class="modal-body">
+                <pre>{{ json_encode($item->configuration(), JSON_PRETTY_PRINT) }}</pre>
+            </div>
+
+            <div class="modal-footer">
+                <x-appshell::button variant="link" data-bs-dismiss="modal">
+                    {{ __('Close') }}
+                </x-appshell::button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/resources/views/order/show/_items.blade.php
+++ b/src/resources/views/order/show/_items.blade.php
@@ -31,6 +31,11 @@
                         @else
                             <a href="{{ route('vanilo.admin.product.show', $item->product) }}">{{ $item->name }}</a>
                         @endif
+
+                        @if ($item->hasConfiguration())
+                            <button data-bs-toggle="modal" data-bs-target="#item-configuration-{{ $loop->index }}" class="btn">{!! icon('settings') !!}</button>
+                            @include('vanilo::order.show._item_configuration')
+                        @endif
                     @else
                         {{ $item->name }}
                     @endif


### PR DESCRIPTION
## Description
Added modal to display configuration JSON of order items.

## Note
As of now, the `->hasConfiguration` method returns `true` for configurations that are empty arrays. Consequently, the button is displayed unnecessarily for items that don't have a configuration. In these cases, only an empty array (`[]`) is displayed in the modal.

## Screenshots:
![image](https://github.com/user-attachments/assets/473807b3-5cb6-4ada-bcc1-fb2e411c86de)
![image](https://github.com/user-attachments/assets/aae4ed93-7ed2-49f0-9390-3ea9c0dc889d)

