### PR TITLE
Fixed master products not being listed on the Channel show page

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@
 - Moved the Orders menu item to the top in the Shop section
 - Added input validation at Property Value assignment
 - Added the configuration widget, that can handle JSON config samples
+- Fixed master products not being listed on the Channel show page
 
 ## 4.1.1
 ##### 2024-07-23

--- a/src/Http/Controllers/ChannelController.php
+++ b/src/Http/Controllers/ChannelController.php
@@ -25,6 +25,7 @@ use Vanilo\Admin\Contracts\Requests\CreateChannel;
 use Vanilo\Admin\Contracts\Requests\UpdateChannel;
 use Vanilo\Channel\Contracts\Channel;
 use Vanilo\Channel\Models\ChannelProxy;
+use Vanilo\Foundation\Search\ProductSearch;
 use Vanilo\Pricing\Models\Pricelist;
 use Vanilo\Support\Features;
 
@@ -70,7 +71,10 @@ class ChannelController extends BaseController
 
     public function show(Channel $channel)
     {
-        return view('vanilo::channel.show', $this->processViewData(__METHOD__, ['channel' => $channel]));
+        return view('vanilo::channel.show', $this->processViewData(__METHOD__, [
+            'channel' => $channel,
+            'channelProducts' => (new ProductSearch())->withinChannel($channel)->withInactiveProducts()->getResults(),
+        ]));
     }
 
     public function edit(Channel $channel)

--- a/src/resources/views/channel/show.blade.php
+++ b/src/resources/views/channel/show.blade.php
@@ -15,7 +15,7 @@
             <x-appshell::button href="#" variant="outline-success" icon="+" size="sm">{{ __('Assign a product') }}</x-appshell::button>
         </x-slot:actions>
 
-        {!! widget('vanilo::channel.products')->render($channel->products) !!}
+        {!! widget('vanilo::channel.products')->render($channelProducts) !!}
 
     </x-appshell::card>
 @stop


### PR DESCRIPTION
## Description:
- Fixed master products not being listed on the Channel show page

## Screenshot after the fix:
![image](https://github.com/user-attachments/assets/f62a6717-43f8-49ec-9e15-d2effd3a6e4a)
