### PR TITLE
Add shipping category to forms

### DIFF
--- a/src/Http/Controllers/MasterProductController.php
+++ b/src/Http/Controllers/MasterProductController.php
@@ -25,6 +25,7 @@ use Vanilo\MasterProduct\Contracts\MasterProductVariant;
 use Vanilo\MasterProduct\Models\MasterProductProxy;
 use Vanilo\Product\Models\ProductStateProxy;
 use Vanilo\Properties\Models\PropertyProxy;
+use Vanilo\Shipment\Models\ShippingCategoryProxy;
 use Vanilo\Support\Features;
 use Vanilo\Taxes\Models\TaxCategoryProxy;
 
@@ -40,6 +41,7 @@ class MasterProductController extends BaseController
             'multiChannelEnabled' => Features::isMultiChannelEnabled(),
             'channels' => $this->channelsForUi(),
             'taxCategories' => TaxCategoryProxy::get(['name', 'id']),
+            'shippingCategories' => ShippingCategoryProxy::get(['name', 'id']),
         ]);
     }
 
@@ -96,6 +98,7 @@ class MasterProductController extends BaseController
             'multiChannelEnabled' => Features::isMultiChannelEnabled(),
             'channels' => $this->channelsForUi(),
             'taxCategories' => TaxCategoryProxy::get(['name', 'id']),
+            'shippingCategories' => ShippingCategoryProxy::get(['name', 'id']),
         ]);
     }
 

--- a/src/Http/Controllers/MasterProductVariantController.php
+++ b/src/Http/Controllers/MasterProductVariantController.php
@@ -23,6 +23,7 @@ use Vanilo\MasterProduct\Contracts\MasterProductVariant;
 use Vanilo\MasterProduct\Models\MasterProductVariantProxy;
 use Vanilo\Product\Models\ProductStateProxy;
 use Vanilo\Properties\Models\PropertyProxy;
+use Vanilo\Shipment\Models\ShippingCategoryProxy;
 
 class MasterProductVariantController extends BaseController
 {
@@ -31,7 +32,8 @@ class MasterProductVariantController extends BaseController
         return view('vanilo::master-product-variant.create', [
             'master' => $masterProduct,
             'variant' => app(MasterProductVariant::class),
-            'states' => ProductStateProxy::choices()
+            'states' => ProductStateProxy::choices(),
+            'shippingCategories' => ShippingCategoryProxy::get(['name', 'id']),
         ]);
     }
 
@@ -89,6 +91,7 @@ class MasterProductVariantController extends BaseController
             'states' => ProductStateProxy::choices(),
             'properties' => PropertyProxy::all(),
             'linkTypes' => LinkTypeProxy::choices(false, true),
+            'shippingCategories' => ShippingCategoryProxy::get(['name', 'id']),
         ]);
     }
 

--- a/src/Http/Controllers/ProductController.php
+++ b/src/Http/Controllers/ProductController.php
@@ -35,6 +35,7 @@ use Vanilo\Product\Contracts\Product;
 use Vanilo\Product\Models\ProductProxy;
 use Vanilo\Product\Models\ProductStateProxy;
 use Vanilo\Properties\Models\PropertyProxy;
+use Vanilo\Shipment\Models\ShippingCategoryProxy;
 use Vanilo\Support\Features;
 use Vanilo\Taxes\Models\TaxCategoryProxy;
 
@@ -116,6 +117,7 @@ class ProductController extends BaseController
             'multiChannelEnabled' => Features::isMultiChannelEnabled(),
             'channels' => $this->channelsForUi(),
             'taxCategories' => TaxCategoryProxy::get(['name', 'id']),
+            'shippingCategories' => ShippingCategoryProxy::get(['name', 'id']),
         ]);
     }
 
@@ -172,6 +174,7 @@ class ProductController extends BaseController
             'multiChannelEnabled' => Features::isMultiChannelEnabled(),
             'channels' => $this->channelsForUi(),
             'taxCategories' => TaxCategoryProxy::get(['name', 'id']),
+            'shippingCategories' => ShippingCategoryProxy::get(['name', 'id']),
         ]);
     }
 

--- a/src/Http/Requests/CreateMasterProduct.php
+++ b/src/Http/Requests/CreateMasterProduct.php
@@ -28,6 +28,7 @@ class CreateMasterProduct extends FormRequest implements CreateMasterProductCont
         return [
             'name' => 'required|min:2|max:255',
             'state' => ['required', Rule::in(ProductStateProxy::values())],
+            'tax_category_id' => 'sometimes|nullable|exists:tax_categories,id',
             'shipping_category_id' => 'sometimes|nullable|exists:shipping_categories,id',
             'price' => 'nullable|numeric',
             'original_price' => 'nullable|numeric',

--- a/src/Http/Requests/CreateMasterProduct.php
+++ b/src/Http/Requests/CreateMasterProduct.php
@@ -28,6 +28,7 @@ class CreateMasterProduct extends FormRequest implements CreateMasterProductCont
         return [
             'name' => 'required|min:2|max:255',
             'state' => ['required', Rule::in(ProductStateProxy::values())],
+            'shipping_category_id' => 'sometimes|nullable|exists:shipping_categories,id',
             'price' => 'nullable|numeric',
             'original_price' => 'nullable|numeric',
             'description' => 'nullable|string',

--- a/src/Http/Requests/CreateMasterProductVariant.php
+++ b/src/Http/Requests/CreateMasterProductVariant.php
@@ -27,6 +27,7 @@ class CreateMasterProductVariant extends FormRequest implements CreateMasterProd
         return [
             'name' => 'required|min:1|max:255',
             'sku' => 'required|unique:products',
+            'shipping_category_id' => 'sometimes|nullable|exists:shipping_categories,id',
             'price' => 'nullable|numeric',
             'original_price' => 'sometimes|nullable|numeric',
             'stock' => 'nullable|numeric',

--- a/src/Http/Requests/CreateProduct.php
+++ b/src/Http/Requests/CreateProduct.php
@@ -29,6 +29,7 @@ class CreateProduct extends FormRequest implements CreateProductContract
             'name' => 'required|min:2|max:255',
             'sku' => 'required|unique:products',
             'state' => ['required', Rule::in(ProductStateProxy::values())],
+            'shipping_category_id' => 'sometimes|nullable|exists:shipping_categories,id',
             'price' => 'nullable|numeric',
             'original_price' => 'sometimes|nullable|numeric',
             'stock' => 'nullable|numeric',

--- a/src/Http/Requests/CreateProduct.php
+++ b/src/Http/Requests/CreateProduct.php
@@ -29,6 +29,7 @@ class CreateProduct extends FormRequest implements CreateProductContract
             'name' => 'required|min:2|max:255',
             'sku' => 'required|unique:products',
             'state' => ['required', Rule::in(ProductStateProxy::values())],
+            'tax_category_id' => 'sometimes|nullable|exists:tax_categories,id',
             'shipping_category_id' => 'sometimes|nullable|exists:shipping_categories,id',
             'price' => 'nullable|numeric',
             'original_price' => 'sometimes|nullable|numeric',

--- a/src/Http/Requests/UpdateMasterProduct.php
+++ b/src/Http/Requests/UpdateMasterProduct.php
@@ -26,6 +26,7 @@ class UpdateMasterProduct extends FormRequest implements UpdateMasterProductCont
         return [
             'name' => 'required|min:2|max:255',
             'state' => ['required', Rule::in(ProductStateProxy::values())],
+            'tax_category_id' => 'sometimes|nullable|exists:tax_categories,id',
             'shipping_category_id' => 'sometimes|nullable|exists:shipping_categories,id',
             'price' => 'nullable|numeric',
             'original_price' => 'nullable|numeric',

--- a/src/Http/Requests/UpdateMasterProduct.php
+++ b/src/Http/Requests/UpdateMasterProduct.php
@@ -26,6 +26,7 @@ class UpdateMasterProduct extends FormRequest implements UpdateMasterProductCont
         return [
             'name' => 'required|min:2|max:255',
             'state' => ['required', Rule::in(ProductStateProxy::values())],
+            'shipping_category_id' => 'sometimes|nullable|exists:shipping_categories,id',
             'price' => 'nullable|numeric',
             'original_price' => 'nullable|numeric',
             'description' => 'nullable|string',

--- a/src/Http/Requests/UpdateMasterProductVariant.php
+++ b/src/Http/Requests/UpdateMasterProductVariant.php
@@ -29,6 +29,7 @@ class UpdateMasterProductVariant extends FormRequest implements UpdateMasterProd
             'sku' => 'required|unique:products',
             'price' => 'nullable|numeric',
             'original_price' => 'sometimes|nullable|numeric',
+            'shipping_category_id' => 'sometimes|nullable|exists:shipping_categories,id',
             'stock' => 'nullable|numeric',
             'backorder' => 'nullable|numeric|min:0',
             'excerpt' => 'sometimes|nullable|max:8192',

--- a/src/Http/Requests/UpdateProduct.php
+++ b/src/Http/Requests/UpdateProduct.php
@@ -30,6 +30,7 @@ class UpdateProduct extends FormRequest implements UpdateProductContract
                 Rule::unique('products')->ignore($this->route('product')->id),
                 ],
             'state' => ['required', Rule::in(ProductStateProxy::values())],
+            'tax_category_id' => 'sometimes|nullable|exists:tax_categories,id',
             'shipping_category_id' => 'sometimes|nullable|exists:shipping_categories,id',
             'price' => 'nullable|numeric',
             'original_price' => 'sometimes|nullable|numeric',

--- a/src/Http/Requests/UpdateProduct.php
+++ b/src/Http/Requests/UpdateProduct.php
@@ -30,6 +30,7 @@ class UpdateProduct extends FormRequest implements UpdateProductContract
                 Rule::unique('products')->ignore($this->route('product')->id),
                 ],
             'state' => ['required', Rule::in(ProductStateProxy::values())],
+            'shipping_category_id' => 'sometimes|nullable|exists:shipping_categories,id',
             'price' => 'nullable|numeric',
             'original_price' => 'sometimes|nullable|numeric',
             'stock' => 'nullable|numeric',

--- a/src/resources/routes/breadcrumbs.php
+++ b/src/resources/routes/breadcrumbs.php
@@ -177,6 +177,26 @@ Breadcrumbs::for('vanilo.admin.shipping-method.edit', function ($breadcrumbs, $s
     $breadcrumbs->push(__('Edit'), route('vanilo.admin.shipping-method.edit', $shippingMethod));
 });
 
+Breadcrumbs::for('vanilo.admin.shipping-category.index', function ($breadcrumbs) {
+    $breadcrumbs->parent('home');
+    $breadcrumbs->push(__('Shipping Categories'), route('vanilo.admin.shipping-category.index'));
+});
+
+Breadcrumbs::for('vanilo.admin.shipping-category.create', function ($breadcrumbs) {
+    $breadcrumbs->parent('vanilo.admin.shipping-category.index');
+    $breadcrumbs->push(__('Create'));
+});
+
+Breadcrumbs::for('vanilo.admin.shipping-category.show', function ($breadcrumbs, $shippingMethod) {
+    $breadcrumbs->parent('vanilo.admin.shipping-category.index');
+    $breadcrumbs->push($shippingMethod->name, route('vanilo.admin.shipping-category.show', $shippingMethod));
+});
+
+Breadcrumbs::for('vanilo.admin.shipping-category.edit', function ($breadcrumbs, $shippingMethod) {
+    $breadcrumbs->parent('vanilo.admin.shipping-category.show', $shippingMethod);
+    $breadcrumbs->push(__('Edit'), route('vanilo.admin.shipping-category.edit', $shippingMethod));
+});
+
 Breadcrumbs::for('vanilo.admin.carrier.index', function ($breadcrumbs) {
     $breadcrumbs->parent('home');
     $breadcrumbs->push(__('Carriers'), route('vanilo.admin.carrier.index'));

--- a/src/resources/views/master-product-variant/_form.blade.php
+++ b/src/resources/views/master-product-variant/_form.blade.php
@@ -23,17 +23,33 @@
 <hr>
 
 <div class="mb-3 row">
-    <label class="col-form-label col-form-label-sm col-md-2">{{ __('State') }}</label>
-    <div class="col-md-4">
-        {{ Form::select('state', $states, null, [
-                'class' => 'form-select form-select-sm' . ($errors->has('state') ? ' is-invalid': ''),
-                'placeholder' => __('--'),
-           ])
-        }}
+    <div class="my-3 col-md-6 col-xl-4">
+        <label class="form-control-label">{{ __('State') }}</label>
+        <div>
+            {{ Form::select('state', $states, null, [
+                    'class' => 'form-select form-select-sm' . ($errors->has('state') ? ' is-invalid': ''),
+                    'placeholder' => __('--'),
+               ])
+            }}
 
-        @if ($errors->has('state'))
-            <div class="invalid-feedback">{{ $errors->first('state') }}</div>
-        @endif
+            @if ($errors->has('state'))
+                <div class="invalid-feedback">{{ $errors->first('state') }}</div>
+            @endif
+        </div>
+    </div>
+
+    <div class="my-3 col-md-6 col-xl-4">
+        <label class="form-control-label">{{ __('Shipping Category') }}</label>
+        <div>
+            {{ Form::select('shipping_category_id', $shippingCategories->pluck('name', 'id'), null, [
+                    'class' => 'form-select form-select-sm' . ($errors->has('shipping_category_id') ? ' is-invalid': ''),
+                    'placeholder' => __('--')
+               ])
+            }}
+            @if ($errors->has('shipping_category_id'))
+                <div class="invalid-feedback">{{ $errors->first('shipping_category_id') }}</div>
+            @endif
+        </div>
     </div>
 </div>
 

--- a/src/resources/views/master-product/_form.blade.php
+++ b/src/resources/views/master-product/_form.blade.php
@@ -19,30 +19,47 @@
 <hr>
 
 <div class="mb-3 row">
-    <label class="col-form-label col-form-label-sm col-md-2">{{ __('State') }}</label>
-    <div class="col-md-4">
-        {{ Form::select('state', $states, null, [
-                'class' => 'form-select form-select-sm' . ($errors->has('state') ? ' is-invalid': ''),
-           ])
-        }}
+    <div class="my-3 col-md-6 col-xl-4">
+        <label class="form-control-label">{{ __('State') }}</label>
+        <div>
+            {{ Form::select('state', $states, null, [
+                    'class' => 'form-select form-select-sm' . ($errors->has('state') ? ' is-invalid': ''),
+               ])
+            }}
 
-        @if ($errors->has('state'))
-            <div class="invalid-feedback">{{ $errors->first('state') }}</div>
-        @endif
+            @if ($errors->has('state'))
+                <div class="invalid-feedback">{{ $errors->first('state') }}</div>
+            @endif
+        </div>
     </div>
 
-    <label class="col-form-label col-form-label-sm col-md-2">{{ __('Tax Category') }}</label>
-    <div class="col-md-4">
-        {{ Form::select('tax_category_id', $taxCategories->pluck('name', 'id'), null, [
-                'class' => 'form-select form-select-sm' . ($errors->has('tax_category_id') ? ' is-invalid': ''),
-                'placeholder' => __('--')
-           ])
-        }}
-        @if ($errors->has('tax_category_id'))
-            <div class="invalid-feedback">{{ $errors->first('tax_category_id') }}</div>
-        @endif
+    <div class="my-3 col-md-6 col-xl-4">
+        <label class="form-control-label">{{ __('Tax Category') }}</label>
+        <div>
+            {{ Form::select('tax_category_id', $taxCategories->pluck('name', 'id'), null, [
+                    'class' => 'form-select form-select-sm' . ($errors->has('tax_category_id') ? ' is-invalid': ''),
+                    'placeholder' => __('--')
+               ])
+            }}
+            @if ($errors->has('tax_category_id'))
+                <div class="invalid-feedback">{{ $errors->first('tax_category_id') }}</div>
+            @endif
+        </div>
     </div>
-</div>
+
+    <div class="my-3 col-md-6 col-xl-4">
+        <label class="form-control-label">{{ __('Shipping Category') }}</label>
+        <div>
+            {{ Form::select('shipping_category_id', $shippingCategories->pluck('name', 'id'), null, [
+                    'class' => 'form-select form-select-sm' . ($errors->has('shipping_category_id') ? ' is-invalid': ''),
+                    'placeholder' => __('--')
+               ])
+            }}
+            @if ($errors->has('shipping_category_id'))
+                <div class="invalid-feedback">{{ $errors->first('shipping_category_id') }}</div>
+            @endif
+        </div>
+    </div>
 
 <hr>
 

--- a/src/resources/views/master-product/_form.blade.php
+++ b/src/resources/views/master-product/_form.blade.php
@@ -60,6 +60,7 @@
             @endif
         </div>
     </div>
+</div>
 
 <hr>
 

--- a/src/resources/views/product/_form.blade.php
+++ b/src/resources/views/product/_form.blade.php
@@ -23,28 +23,46 @@
 <hr>
 
 <div class="mb-3 row">
-    <label class="col-form-label col-form-label-sm col-md-2">{{ __('State') }}</label>
-    <div class="col-md-4">
-        {{ Form::select('state', $states, null, [
-                'class' => 'form-select form-select-sm' . ($errors->has('state') ? ' is-invalid': ''),
-           ])
-        }}
+    <div class="my-3 col-md-6 col-xl-4">
+        <label class="form-control-label">{{ __('State') }}</label>
+        <div>
+            {{ Form::select('state', $states, null, [
+                    'class' => 'form-select form-select-sm' . ($errors->has('state') ? ' is-invalid': ''),
+               ])
+            }}
 
-        @if ($errors->has('state'))
-            <div class="invalid-feedback">{{ $errors->first('state') }}</div>
-        @endif
+            @if ($errors->has('state'))
+                <div class="invalid-feedback">{{ $errors->first('state') }}</div>
+            @endif
+        </div>
     </div>
 
-    <label class="col-form-label col-form-label-sm col-md-2">{{ __('Tax Category') }}</label>
-    <div class="col-md-4">
-        {{ Form::select('tax_category_id', $taxCategories->pluck('name', 'id'), null, [
-                'class' => 'form-select form-select-sm' . ($errors->has('tax_category_id') ? ' is-invalid': ''),
-                'placeholder' => __('--')
-           ])
-        }}
-        @if ($errors->has('tax_category_id'))
-            <div class="invalid-feedback">{{ $errors->first('tax_category_id') }}</div>
-        @endif
+    <div class="my-3 col-md-6 col-xl-4">
+        <label class="form-control-label">{{ __('Tax Category') }}</label>
+        <div>
+            {{ Form::select('tax_category_id', $taxCategories->pluck('name', 'id'), null, [
+                    'class' => 'form-select form-select-sm' . ($errors->has('tax_category_id') ? ' is-invalid': ''),
+                    'placeholder' => __('--')
+               ])
+            }}
+            @if ($errors->has('tax_category_id'))
+                <div class="invalid-feedback">{{ $errors->first('tax_category_id') }}</div>
+            @endif
+        </div>
+    </div>
+
+    <div class="my-3 col-md-6 col-xl-4">
+        <label class="form-control-label">{{ __('Shipping Category') }}</label>
+        <div>
+            {{ Form::select('shipping_category_id', $shippingCategories->pluck('name', 'id'), null, [
+                    'class' => 'form-select form-select-sm' . ($errors->has('shipping_category_id') ? ' is-invalid': ''),
+                    'placeholder' => __('--')
+               ])
+            }}
+            @if ($errors->has('shipping_category_id'))
+                <div class="invalid-feedback">{{ $errors->first('shipping_category_id') }}</div>
+            @endif
+        </div>
     </div>
 </div>
 


### PR DESCRIPTION
- Added shipping category to product forms
- Slightly changed form layout to better incorporate the new field
- Added validation rules for `shipping_category_id`

_Note_: Added missing validation rules for `tax_category_id`

![image](https://github.com/user-attachments/assets/9d416d3d-d523-4ac3-86bb-c18853612cb6)
![image](https://github.com/user-attachments/assets/e2a15e02-7e23-4617-8f21-f39b0c5a5765)
![image](https://github.com/user-attachments/assets/2d5378ca-2bba-42db-851a-3fcb16fb279f)
